### PR TITLE
Improved grammar/typos/readability & formatting

### DIFF
--- a/dd17fe9825022be7.css
+++ b/dd17fe9825022be7.css
@@ -3369,3 +3369,14 @@ button.date-input{
     opacity:.4;
     transform:rotate(3deg) translateY(-4px)
 }
+#key-format {
+    width:auto;
+    height:auto;
+    margin-top:25px;
+    margin-bottom:25px;
+    background-color:#2a2a2a;
+    border:2px solid grey;
+    text-align:center;
+    border-radius:10px;
+    padding:10px;
+}

--- a/index.html
+++ b/index.html
@@ -603,14 +603,14 @@ input[type="checkbox"]:checked ~ nav > ul {
 
 <h4 id="q-is-pandanite-pdn-a-fork-of-bitcoin-or-any-other-coin">Q. Is Pandanite (PDN) a fork of Bitcoin or any other coin?</h4>
 
-<p>No, Pandanite is developed from scratch and uses its unique algorithm. 100 million coins in 6k lines of codebase written from scratch in C++. It can be called first of its kind and first crypto to implement Pufferfish2 algo for to secure a POW network.</p>
+<p>No, Pandanite is developed from scratch and uses its unique algorithm. 100 million coins in 6k lines of codebase written from scratch in C++. It can be called first of its kind and the first crypto to implement the Pufferfish2 algorithm to secure a POW network.</p>
 
 <h4 id="q-is-pandanite-a-token">Q. Is Pandanite a token?</h4>
 
 <p>No, it has its own mainnet and own chain secured by Proof of Work (POW) just like Bitcoin.</p>
 
 <h4 id="q-is-pdn-infinite">Q. Is PDN infinite?</h4>
-<p>No. It is hard capped at 100 million coins, meaning only 100 million PDN will ever exists. So it is similar to Bitcoin and can be a strore of value later on.</p>
+<p>No. It is hard capped at 100 million coins, meaning only 100 million PDN will ever exist. So it is similar to Bitcoin and can be a store of value later on.</p>
 
 <h4 id="q-where-is-the-github">Q. Where is the GitHub?</h4>
 
@@ -665,13 +665,13 @@ input[type="checkbox"]:checked ~ nav > ul {
 
 <h4 id="q-what-is-the-smallest-unit-of-pdn-what-does-leaf-mean">Q. What is the smallest unit of PDN? What does LEAF mean?</h4>
 
-<p>It is a relic from when PDN was called Bamboo. Bamboo plant has small leaves, so a leaf is a small measure unit for a PDN coin. 1 LEAF = 0,0001 PDN</p>
+<p>It is a relic from when PDN was called Bamboo. The Bamboo plant has small leaves, so a leaf is a small measure unit for a PDN coin. 1 LEAF = 0,0001 PDN</p>
 
 <p>Or it can be called pandtoshi just like satoshi in case of BTC.</p>
 
-<h4 id="q-when-will-pdn-be-listed-on-coin-aggregate-sites-such-as-cmc-coingecko-coinpaprika">Q. When will PDN be listed on coin aggregate sites such as CMC, CoinGecko, CoinPaprika?</h4>
+<h4 id="q-when-will-pdn-be-listed-on-coin-aggregate-sites-such-as-cmc-coingecko-coinpaprika">Q. When will PDN be listed on coin aggregate sites such as Coinmarketcap, CoinGecko, and CoinPaprika?</h4>
 
-<p>We are actively striving towards the goal to be listed on these sites. As a matter of fact PDN is already tracked by CoinPaprika and other sites:</p>
+<p>PDN is already tracked by CoinPaprika, Coincodex, and similar sites. Efforts are being made to list the coin on Coingecko and Coinmarketcap.</p>
 
 <ul>
   <li><a href="https://coinpaprika.com/coin/pdn-pandanite/">https://coinpaprika.com/coin/pdn-pandanite/</a></li>
@@ -687,18 +687,18 @@ input[type="checkbox"]:checked ~ nav > ul {
 <p><a href="Whitepaper">https://github.com/pandanite-crypto/pdnpaper/blob/main/whitepaper.pdf</a></p>
 
 <h4 id="q-when-smart-contracts">Q. When Smart Contracts?</h4>
-<p>Because the custom lightweight C++ code it is hard to implement something like that without heavy modification.</p>
+<p>Because of the custom lightweight C++ code it is hard to implement something like that without heavy modification.</p>
 
-<h4 id="q-when-smart-nodes">Q. When Smart Nodes?</h4>
-<p>Same as before its not that easy to switch to POS or a hybrid method of POW/POS and we like PDN to be decentralized and secured by POW.</p>
+<h4 id="q-when-smart-nodes">Q. When will there be Smart Nodes?</h4>
+<p>Its not that easy to switch to POS or a hybrid method of POW/POS and we like PDN to be decentralized and secured by POW.</p>
 
 <h4 id="q-is-the-team-finnish">Q. Is the team Finnish?</h4>
 
-<p>The team is international, we have more than 600 community members from all around the globe.</p>
+<p>The team is international. We have more than 600 community members from all around the globe.</p>
 
 <h4 id="q-how-do-i-know-if-the-node-port-is-open">Q. How do I know if the node port is open?</h4>
 
-<p>Test if port 3000 is open on your machine, for example <a href="https://www.yougetsignal.com/tools/open-ports/">https://www.yougetsignal.com/tools/open-ports/</a> If port is not open make sure you open it in the admin panel if you are renting VPS or in your router if you are running your node at home, also add appropriate firewall rules.</p>
+<p>Test if port 3000 is open on your machine, for example <a href="https://www.yougetsignal.com/tools/open-ports/">https://www.yougetsignal.com/tools/open-ports/</a> If port is not open make sure you open it in the admin panel if you are renting VPS or in your router if you are running your node at home. Also, remember to add appropriate firewall rules.</p>
 
 <h4 id="q-why-arent-there-any-marketing-campaigns">Q. Why aren’t there any marketing campaigns?</h4>
 
@@ -706,7 +706,7 @@ input[type="checkbox"]:checked ~ nav > ul {
 
 <h4 id="q-my-antivirus-scanner-says-wallet-and-miner-executables-contain-lots-of-viruses-and-trojan-horses-why-is-that">Q. My antivirus scanner says wallet and miner executables contain lots of viruses and trojan horses, why is that?</h4>
 
-<p>Usually antivirus software companies mark mining executables as viruses because some people use computers for mining without the computer owner’s consent, that kind of behavior is against ToS or even illegal in case of botnets. If you are the owner of the computer used for mining it’s just a false positive alert, add it to exceptions. But make sure you download only from the official website or github repository and verify the hash of the file.</p>
+<p>Usually antivirus software companies mark mining executables as viruses because some people use computers for mining without the computer owner’s consent. That kind of behavior is against ToS or even illegal in case of botnets. If you are the owner of the computer used for mining it’s just a false positive alert, add it to exceptions. But make sure you download only from the official website or github repository and verify the hash of the file.</p>
 
 <h4 id="q-i-have-many-years-of-experience-in-blockchain-development-can-i-join-the-team">Q. I have many years of experience in blockchain development. Can I join the team?</h4>
 
@@ -750,29 +750,33 @@ input[type="checkbox"]:checked ~ nav > ul {
 <ul>
   <li><a href="https://github.com/pandanite-crypto/pandanite#getting-started">https://github.com/pandanite-crypto/pandanite#getting-started</a></li>
 </ul>
-
+<br>
 <h4 id="troubleshooting-common-problems">Troubleshooting common problems:</h4>
 
-<p>Mining payment not arriving: ping pool operators on discord.</p>
 
-<p>Can’t mine with Decrypted miner with GPU: ofc because its CPU only.</p>
+<p><b>Mining payment is not arriving</b></p>
+<p>Ping the relevant pool operators. Some may be on Discord.</p>
 
-<p>How to use HiveOS? <a href="https://github.com/pandanite-crypto/pandanite-hiveos">https://github.com/pandanite-crypto/pandanite-hiveos</a></p>
+<p><b>Can’t mine using Decrypted with a GPU</b></p>
+<p>Of course, because Decrypted is a CPU only miner.</p>
 
-<p>I have old client build from BMB times: no problem you need publicKey/privateKey/wallet address and format it like then f10 wallet can read it:
-{
-    “privateKey”: “XXXXXX”,
-    “publicKey”: “XXXXXX”,
-    “wallet”: “XXXXXX”
-}</p>
+<p><b>How do I use HiveOS?</b></p>
+<p>See instruction in the following link: <a href="https://github.com/pandanite-crypto/pandanite-hiveos">https://github.com/pandanite-crypto/pandanite-hiveos</a></p>
 
-<p>Old wallet: <a href="https://github.com/f10crypto/bamboowallet/releases">https://github.com/f10crypto/bamboowallet/releases</a></p>
+<p><b>I have old client build from when the coin was called BMB</b></p>
+<p>This is no problem. You need a publicKey, privateKey, and wallet address. If you format it like the following, then the old "f10 wallet" can read it:<br>
+<div id="key-format">
+	{ “privateKey”: “XXXXXX”,<br>
+	“publicKey”: “XXXXXX”,<br>
+	“wallet”: “XXXXXX” }<br>
+</div></p>
 
-<h4 id="q-how-to-keep-an-android-phone-from-screen-locking">Q. How to keep an android phone from screen locking:</h4>
+<p>Here is a link to the old wallet: <a href="https://github.com/f10crypto/bamboowallet/releases">https://github.com/f10crypto/bamboowallet/releases</a></p>
 
-<p><a href="https://www.xda-developers.com/how-to-enable-always-on-display-android/">https://www.xda-developers.com/how-to-enable-always-on-display-android/</a></p>
+<p><span id="q-how-to-keep-an-android-phone-from-screen-locking" style="font-weight:bold;">How do I keep an android phone from screen locking?</span><p>
+<p>First, try the instruction contained in this link: <a href="https://www.xda-developers.com/how-to-enable-always-on-display-android/">https://www.xda-developers.com/how-to-enable-always-on-display-android/</a></p>
 
-<p>If it didn’t help, you can acquire “developer’s mode” by tapping several times on firmware version of your phone and then try enabling “Always on while charging” option in developer’s options</p>
+<p>If that didn’t help, you can turn on “developer’s mode” by tapping several times on the firmware version of your phone. Then try enabling the “Always on while charging” option in developer’s options</p>
 
 
   


### PR DESCRIPTION
There were a few typos in the page, as well as grammar errors.  Changed the headers in the troubleshoot section as bold, and broke up wrap-around text in the answers section of troubleshooting.  Improved readability in some text sections.  Properly
formatted the wallet-address code section to be more easily readable with some extra css is dd17fe9825022be7.css